### PR TITLE
Fix mobile arrow visibility and about alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -312,6 +312,7 @@ body.bg-pulse::after {
   height: 24px;
   color: var(--accent-color);
   opacity: 0.7;
+  z-index: 5;
   transition: opacity 0.3s, transform 0.3s;
 }
 
@@ -659,6 +660,6 @@ section h2 {
     gap: 2rem;
   }
   .about {
-    align-items: flex-start;
+    align-items: center;
   }
 }


### PR DESCRIPTION
## Summary
- ensure down arrows layer above content on mobile
- center the About section on small screens

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_688435729dcc83239463240cade101ed