### PR TITLE
Fix mobile down-arrow position

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -303,7 +303,7 @@ body.bg-pulse::after {
 
 /* Arrow linking to next section */
 .down-arrow {
-  position: absolute;
+  position: fixed;
   left: 50%;
   bottom: 1.5rem;
   transform: translate(-50%, 0);


### PR DESCRIPTION
## Summary
- keep down arrow fixed to the bottom of the viewport so it doesn't scroll away

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68856e83afa88323a96813f5258cfb72