### PR TITLE
Improve down arrow visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,6 +50,26 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   };
 
+  let interactionTimeout;
+  const hideArrow = () => {
+    if (downArrow) {
+      downArrow.classList.add("hidden");
+    }
+  };
+  const showArrow = () => {
+    if (downArrow && downArrow.style.display !== "none") {
+      downArrow.classList.remove("hidden");
+    }
+  };
+  const scheduleArrowShow = () => {
+    clearTimeout(interactionTimeout);
+    interactionTimeout = setTimeout(showArrow, 3000);
+  };
+  const handleInteraction = () => {
+    hideArrow();
+    scheduleArrowShow();
+  };
+
   const setBodyHeight = () => {
     document.body.style.height = `${panels.length * viewportHeight}px`;
   };
@@ -57,6 +77,10 @@ document.addEventListener("DOMContentLoaded", () => {
   setBodyHeight();
   createDownArrow();
   updateDownArrow();
+
+  ["scroll", "mousemove", "keydown", "touchstart"].forEach((evt) =>
+    window.addEventListener(evt, handleInteraction, { passive: true })
+  );
 
   const observer = new IntersectionObserver(
     (entries, obs) => {

--- a/styles.css
+++ b/styles.css
@@ -266,6 +266,11 @@ body.bg-pulse::before {
   height: 100%;
 }
 
+.down-arrow.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
 @media (min-width: 600px) {
   .down-arrow {
     bottom: 3rem;


### PR DESCRIPTION
## Summary
- hide the down arrow while the user is interacting with the page
- restore the arrow 3 seconds after interaction stops

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688612c605148323ba6f2ae2eb016d28