### PR TITLE
Fix panel centering

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,6 +23,13 @@ document.addEventListener("DOMContentLoaded", () => {
   updateViewportHeight();
 
   let downArrow;
+
+  const updateArrowPosition = () => {
+    if (!downArrow) return;
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    downArrow.style.left = `calc(50% + ${scrollbarWidth / 2}px)`;
+  };
+
   const createDownArrow = () => {
     const arrowSvg =
       '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9" /></svg>';
@@ -38,6 +45,7 @@ document.addEventListener("DOMContentLoaded", () => {
       window.scrollToSection(nextId);
     });
     document.body.appendChild(downArrow);
+    updateArrowPosition();
   };
 
   const updateDownArrow = () => {
@@ -48,6 +56,7 @@ document.addEventListener("DOMContentLoaded", () => {
       downArrow.href = `#${nextId}`;
       downArrow.style.display = "flex";
     }
+    updateArrowPosition();
   };
 
   let interactionTimeout;
@@ -188,6 +197,7 @@ document.addEventListener("DOMContentLoaded", () => {
     updateViewportHeight();
     setBodyHeight();
     updatePanels();
+    updateArrowPosition();
   });
   updatePanels();
   window.scrollToSection = (id) => {

--- a/script.js
+++ b/script.js
@@ -24,11 +24,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   let downArrow;
 
-  const updateArrowPosition = () => {
-    if (!downArrow) return;
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-    downArrow.style.left = `calc(50% + ${scrollbarWidth / 2}px)`;
-  };
 
   const createDownArrow = () => {
     const arrowSvg =
@@ -45,7 +40,6 @@ document.addEventListener("DOMContentLoaded", () => {
       window.scrollToSection(nextId);
     });
     document.body.appendChild(downArrow);
-    updateArrowPosition();
   };
 
   const updateDownArrow = () => {
@@ -56,7 +50,6 @@ document.addEventListener("DOMContentLoaded", () => {
       downArrow.href = `#${nextId}`;
       downArrow.style.display = "flex";
     }
-    updateArrowPosition();
   };
 
   let interactionTimeout;
@@ -197,7 +190,6 @@ document.addEventListener("DOMContentLoaded", () => {
     updateViewportHeight();
     setBodyHeight();
     updatePanels();
-    updateArrowPosition();
   });
   updatePanels();
   window.scrollToSection = (id) => {

--- a/styles.css
+++ b/styles.css
@@ -65,6 +65,8 @@ body {
   inset: 0;
   overflow: hidden;
   z-index: 1;
+  margin-left: calc((100vw - 100%) / 2);
+  margin-right: calc((100vw - 100%) / 2);
 }
 
 .panel {
@@ -200,7 +202,7 @@ body {
 /* Arrow linking to next section */
 .down-arrow {
   position: fixed;
-  left: 50%;
+  left: 50vw;
   bottom: 2rem;
   transform: translate(-50%, 0);
   width: 28px;

--- a/styles.css
+++ b/styles.css
@@ -202,7 +202,7 @@ body {
 /* Arrow linking to next section */
 .down-arrow {
   position: fixed;
-  left: 50vw;
+  left: calc(50% + (100vw - 100%) / 2);
   bottom: 2rem;
   transform: translate(-50%, 0);
   width: 28px;


### PR DESCRIPTION
## Summary
- compensate for the browser scrollbar so panels stay centred
- simplify the down-arrow logic
- ensure down arrow and panels use the same center point

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6887879c88c48323b9ec9d5c3d50c8f3