### PR TITLE
Fix contact section showing through during scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -196,6 +196,7 @@ document.addEventListener("DOMContentLoaded", () => {
       panel.style.opacity = opacity;
       panel.style.transform = `scale(${scale})`;
       panel.style.pointerEvents = opacity > 0.1 ? "auto" : "none";
+      panel.style.zIndex = Math.round(opacity * 100);
     });
 
   };


### PR DESCRIPTION
## Summary
- set panel z-index from opacity to keep off-screen sections behind current panel

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f1b0047848323a940ec4d6118e8ef